### PR TITLE
Fix sql ambiguity when saving associated user

### DIFF
--- a/Controller/Adminhtml/Vendor/Save.php
+++ b/Controller/Adminhtml/Vendor/Save.php
@@ -142,7 +142,7 @@ class Save extends Action
         $collection = $this->userCollectionFactory->create();
         $assocVendorUsers = $collection->addFieldToFilter(
             [
-                'user_id',
+                'main_table.user_id',
                 'assoc_vendor_id',
             ],
             [


### PR DESCRIPTION
When editing vendor users or even just visiting the Vendor Users -> Users tab, the vendor cannot be saved.